### PR TITLE
MARK: Add thorough type checking and fastpath modes for webidl_binder.py.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -35,6 +35,9 @@ try:
 except:
   raise Exception('Cannot find "COMPILER_OPTS" definition. Is %s set up properly? You may need to copy the template settings file into it.' % EM_CONFIG)
 
+# Force IDL checks
+os.environ['IDL_CHECKS'] = 'ALL'
+
 # Core test runner class, shared between normal tests and benchmarks
 checked_sanity = False
 test_modes = ['default', 'asm1', 'asm2', 'asm3', 'asm2f', 'asm2g', 'asm1i', 'asm3i', 'asm2nn']

--- a/tests/webidl/output.txt
+++ b/tests/webidl/output.txt
@@ -92,5 +92,12 @@ struct_array[7].attr1 == 14
 struct_array[7].attr2 == 18
 struct_ptr_array[0]->attr1 == 100
 struct_ptr_array[0]->attr2 == 101
+Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
+Parent:42
+Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>
 
 done.
+Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
+Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -207,6 +207,23 @@ arrayClass.set_struct_ptr_array(0, struct);
 TheModule.print('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
 TheModule.print('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
 
+
+// Test IDL_CHECKS=ALL
+
+try {
+  p = new TheModule.Parent(NaN); // Expects an integer
+} catch (e) {}
+
+try {
+  p = new TheModule.Parent(42);
+  p.voidStar(1234) // Expects a wrapped pointer
+} catch (e) {}
+
+try {
+  s = new TheModule.StringUser('abc', 1);
+  s.Print(123, null); // Expects a string or a wrapped pointer
+} catch (e) {}
+
 //
 
 TheModule.print('\ndone.')


### PR DESCRIPTION
**PREVIEW BEFORE I SUBMIT ON ORIGINAL REPO**
- Setting `IDL_CHECKS=ALL` in your env will add thorough argument checking to the wrapper methods, catching NaNs, invalid pointers, invalid strings, etc. Note that we only special cased the most common argument types for simplicity; may extend later as needed.
- Setting `IDL_CHECKS=FAST` in your env will skip most type checking for performance (~3x faster than default).
- Setting `IDL_CHECKS` to anything else, or not setting it will behave as before, ensuring backward compatibility.
- Setting `IDL_VERBOSE=1` in your env will print debug info during render_function.
- Added inline type comments for readability: `argN <Type> [innerType]`.

`IDL_CHECKS=ALL`:

``` js
// StringUser
function StringUser(arg0, arg1) {
  /* arg0 <String> [] */
  if(typeof arg0 !== 'undefined' && arg0 !== null) {
    assert(typeof arg0 === 'string' || (arg0 && typeof arg0 === 'object' && typeof arg0.ptr === 'number'), '[CHECK FAILED] StringUser::StringUser(arg0:str): Expecting <string>');
  }
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  /* arg1 <Long> [] */
  if(typeof arg1 !== 'undefined' && arg1 !== null) {
    assert(typeof arg1 === 'number' && !isNaN(arg1), '[CHECK FAILED] StringUser::StringUser(arg1:i): Expecting <integer>');
  }
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```

`IDL_CHECKS=FAST`:

``` js
// StringUser
function StringUser(arg0, arg1) {
  /* arg0 <String> [] */
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  /* arg1 <Long> [] */
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```

legacy:

``` js
// StringUser
function StringUser(arg0, arg1) {
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  if (arg1 && typeof arg1 === 'object') arg1 = arg1.ptr;
  else arg1 = ensureString(arg1);
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```
